### PR TITLE
Add Nim language learning examples and nimble tasks

### DIFF
--- a/NimLearning.nimble
+++ b/NimLearning.nimble
@@ -1,5 +1,6 @@
 # NimLearning.nimble
 # Nimble package definition for the Nim Learning educational project.
+import std/[os, strutils]
 
 let baseOptions       = @["--hint[Processing]:off", "--hint[Conf]:off"]
 let debugOptions      = baseOptions & @["-g", "--lineDir:on", "--stackTrace:on"]
@@ -8,7 +9,15 @@ let gccBackend        = @["--cc:gcc"]
 let clangCppBackend   = @["--cc:clang", "--cpp"]
 let defaultBackend    = gccBackend
 let compileSteps      = @["c"]
+let runStep          = @["r"]
 let mainModule        = "src/nim_learning.nim"
+
+let exampleModules   = @[
+  "examples/basic_control_flow.nim",
+  "examples/abstractions_and_metaprogramming.nim",
+  "examples/error_handling_and_options.nim",
+  "examples/interop_c_and_cpp.nim"
+]
 
 proc joinOptions(options: seq[string]): string =
   result = ""
@@ -17,10 +26,38 @@ proc joinOptions(options: seq[string]): string =
       result.add(' ')
     result.add(opt)
 
-proc runBuild(options: seq[string]) =
-  let command = "nim " & joinOptions(options & @[mainModule])
+proc runNimCommand(options: seq[string], module: string) =
+  let command = "nim " & joinOptions(options & @[module])
   echo "Executing: " & command
   exec command
+
+proc runBuild(options: seq[string]) =
+  runNimCommand(options, mainModule)
+
+proc addNimExtension(fileName: string): string =
+  if fileName.endsWith(".nim"):
+    fileName
+  else:
+    fileName & ".nim"
+
+proc locateExample(target: string): string =
+  if target.len == 0:
+    return ""
+  let normalized = addNimExtension(target)
+  for module in exampleModules:
+    if module == normalized or module.endsWith(normalized):
+      return module
+  let direct = normalized
+  let nested = joinPath("examples", normalized)
+  if fileExists(direct):
+    return direct
+  if fileExists(nested):
+    return nested
+  ""
+
+proc compileExamples(options: seq[string]) =
+  for module in exampleModules:
+    runNimCommand(options, module)
 
 # Package
 
@@ -28,7 +65,8 @@ version       = "0.1.0"
 author        = "Nim Learning Contributors"
 description   = "Educational resources and examples for learning the Nim programming language."
 license       = "MIT"
-name          = "nimlearning"
+when compiles(name = "nimlearning"):
+  name          = "nimlearning"
 srcDir        = "src"
 
 # Dependencies
@@ -52,3 +90,31 @@ task buildC, "Build the main module targeting the C backend with GCC":
 task buildCpp, "Build the main module targeting the C++ backend with Clang":
   let opts = releaseOptions & clangCppBackend & compileSteps
   runBuild(opts)
+
+task examplesDebug, "Compile all example modules with debug options":
+  let opts = debugOptions & defaultBackend & compileSteps
+  compileExamples(opts)
+
+task examplesRelease, "Compile all example modules with release options":
+  let opts = releaseOptions & defaultBackend & compileSteps
+  compileExamples(opts)
+
+task runExample, "Run a single example module. Provide the name (with or without .nim) as an argument or set EXAMPLE.":
+  var target = getEnv("EXAMPLE")
+  let params = commandLineParams()
+  for i in 0 ..< params.len - 1:
+    if params[i] == "runExample":
+      target = params[i + 1]
+      break
+  if target.len == 0 and params.len > 0:
+    let candidate = params[params.len - 1]
+    if candidate.len > 0 and candidate[0] != '-' and candidate != "runExample" and not candidate.endsWith(".nim") and not candidate.endsWith(".nims"):
+      target = candidate
+  if target.len == 0:
+    quit "Specify an example to run. Available modules: " & exampleModules.join(", ")
+  let module = locateExample(target)
+  if module.len == 0:
+    quit "Could not find example '" & target & "'. Available modules: " & exampleModules.join(", ")
+  let opts = debugOptions & defaultBackend & runStep
+  runNimCommand(opts, module)
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,98 @@
+# Example Programs
+
+These standalone examples illustrate core Nim language features. Run each file
+with `nim r examples/<name>.nim` unless noted otherwise.
+
+You can also run any example through the Nimble task `nimble runExample`. Pass the module name as an argument or set the `EXAMPLE` environment variable, e.g. `nimble runExample basic_control_flow` or `EXAMPLE=error_handling_and_options nimble runExample`.
+
+## `basic_control_flow.nim`
+- **Command:** `nim r examples/basic_control_flow.nim`
+- **Highlights:** Immutable and mutable variables, branching with `if`/`elif`/`else`,
+  loops, exception handling basics.
+- **Expected output:**
+
+```
+=== Control Flow Demonstration ===
+Hello Avery, hope work is going well.
+
+--- Number classification ---
+-2 is negative and even.
+-1 is negative and odd.
+0 is zero and even.
+1 is positive and odd.
+2 is positive and even.
+3 is positive and odd.
+
+--- Countdown ---
+5 4 3 2 1 0
+Blastoff!
+
+--- Error handling preview ---
+Tried to build a countdown with -1 and caught: Countdown requires a non-negative start.
+```
+
+## `abstractions_and_metaprogramming.nim`
+- **Command:** `nim r examples/abstractions_and_metaprogramming.nim`
+- **Highlights:** Generic procedures, custom iterators, templates for code reuse,
+  and macros for compile-time debugging.
+- **Expected output:**
+
+```
+------------------- Generic boxes
+Base value: 21
+Doubled value: 42
+------------------- end
+--------------------- Custom iterator
+Taking every other word:
+Nim metaprogramming
+
+--------------------- end
+--------------------- Macro debugging
+[debug] 14 = 14
+Result still available as a value: 14
+--------------------- end
+```
+
+## `error_handling_and_options.nim`
+- **Command:** `nim r examples/error_handling_and_options.nim`
+- **Highlights:** Defining custom exceptions, working with `Option[T]`, and using
+  `try`/`except` blocks to recover from failures.
+- **Expected output:**
+
+```
+=== Option type parsing ===
+Successfully parsed 42 as 42.
+Input -10 is not a positive integer.
+Input abc is not a positive integer.
+
+=== Exception handling ===
+10.0 / 2.0 = 5.0
+Could not divide 5.0 by 0.0: Cannot divide by zero or near-zero.
+
+=== Options from divisions ===
+Quotient is 3.0.
+Division failed for 1.0 / 0.0.
+```
+
+## `interop_c_and_cpp.nim`
+- **Command:** `nim r examples/interop_c_and_cpp.nim`
+- **Highlights:** Calling C standard library functions using `importc`.
+- **Expected output:**
+
+```
+Byte length reported by strlen: 21
+Printed by the C standard library.
+```
+
+To demonstrate the optional C++ integration, compile and run with the C++
+backend instead:
+
+```
+nim cpp --run examples/interop_c_and_cpp.nim
+```
+
+Expected additional output in that mode:
+
+```
+C++ helper reports 7 + 1 = 8
+```

--- a/examples/abstractions_and_metaprogramming.nim
+++ b/examples/abstractions_and_metaprogramming.nim
@@ -1,0 +1,111 @@
+## Examples that combine procedures, generics, iterators, templates, and macros.
+##
+## Run with `nim r examples/abstractions_and_metaprogramming.nim` to follow each
+## demonstration in the console.
+
+import std/[macros, strformat, strutils]
+
+
+type
+  ## Box* wraps a value of any type so generic procedures can transform it.
+  ##
+  ## Parameters:
+  ## * `T` — Compile-time type parameter representing the stored value.
+  ##
+  ## The type exports the `value` field to make pattern matching and
+  ## destructuring easy in downstream modules.
+  Box*[T] = object
+    value*: T
+
+
+## initBox* constructs a `Box` for convenient generic experimentation.
+##
+## Parameters:
+## * `value` — The payload to store inside the box.
+##
+## Use this helper to avoid explicit type annotations when creating boxes. The
+## compiler infers `T` automatically based on the provided argument.
+proc initBox*[T](value: T): Box[T] =
+  Box[T](value: value)
+
+
+## mapBox* applies `transform` to the inner value and returns a new `Box`.
+##
+## Parameters:
+## * `box` — Source container to transform.
+## * `transform` — Callback receiving the boxed value and returning a new type.
+##
+## The procedure demonstrates higher-order functions combined with generics.
+## It is intentionally simple yet expressive enough to showcase type inference.
+proc mapBox*[T, U](box: Box[T], transform: proc (value: T): U): Box[U] =
+  Box[U](value: transform(box.value))
+
+
+## everyOther* yields every second element from `items`.
+##
+## Parameters:
+## * `items` — Any sequence-like container that supports indexing.
+##
+## The iterator demonstrates stateful iteration with captured variables. Use it
+## to observe how Nim lazily produces values without allocating intermediate
+## sequences.
+iterator everyOther*[T](items: openArray[T]): T =
+  var index = 0
+  for item in items:
+    if (index mod 2) == 0:
+      yield item
+    inc index
+
+
+## withSeparator* prints a visual separator before and after executing `body`.
+##
+## Parameters:
+## * `label` — Short description inserted into the separator line.
+## * `body` — Code block executed between the separator lines.
+##
+## Templates run at compile time and perform lightweight code generation. This
+## one keeps output formatting tidy while allowing call sites to stay compact.
+template withSeparator*(label: string, body: untyped): untyped =
+  block:
+    let width = if label.len < 4: 4 else: label.len
+    let border = repeat('-', width + 6)
+    echo border, " ", label
+    body
+    echo border, " end"
+
+
+## debugExpression* evaluates `expr`, prints its AST representation, and returns
+## the computed value.
+##
+## Parameters:
+## * `expr` — Any expression to evaluate and debug.
+##
+## The macro showcases compile-time metaprogramming. It generates a let-binding
+## with a unique symbol, echoes the expression, and yields the result so callers
+## can continue chaining computations.
+macro debugExpression*(expr: typed): untyped =
+  let tmp = genSym(nskLet, "tmp")
+  let exprStr = newLit(expr.repr)
+  result = quote do:
+    let `tmp` = `expr`
+    echo "[debug] ", `exprStr`, " = ", `tmp`
+    `tmp`
+
+
+when isMainModule:
+  withSeparator "Generic boxes":
+    let baseBox = initBox(21)
+    let doubledBox = mapBox(baseBox, proc (value: int): int = value * 2)
+    echo fmt"Base value: {baseBox.value}"
+    echo fmt"Doubled value: {doubledBox.value}"
+
+  withSeparator "Custom iterator":
+    let words = @["Nim", "makes", "metaprogramming", "approachable"]
+    echo "Taking every other word:" 
+    for word in everyOther(words):
+      stdout.write(word & " ")
+    echo "\n"
+
+  withSeparator "Macro debugging":
+    let computed = debugExpression((3 + 4) * 2)
+    echo fmt"Result still available as a value: {computed}"

--- a/examples/basic_control_flow.nim
+++ b/examples/basic_control_flow.nim
@@ -1,0 +1,94 @@
+## Basic control flow demonstrations with simple data types and loops.
+##
+## Run with `nim r examples/basic_control_flow.nim` to see each concept in action.
+
+import std/strformat
+
+
+type
+  ## Person* represents a person with a name and age for branching examples.
+  ##
+  ## Parameters:
+  ## * `name` — Display name for greeting output.
+  ## * `age` — Used to demonstrate chained `if` statements.
+  Person* = object
+    name*: string
+    age*: int
+
+
+## classifyNumber* returns a textual description for `n`.
+##
+## The result includes information about whether the number is negative,
+## zero, or positive, and whether it is even or odd. This procedure is used to
+## illustrate `if`, `elif`, and `else` logic. Pass any integer to explore the
+## resulting classifications.
+proc classifyNumber*(n: int): string =
+  var kind =
+    if n < 0:
+      "negative"
+    elif n == 0:
+      "zero"
+    else:
+      "positive"
+
+  if n mod 2 == 0:
+    kind.add " and even"
+  else:
+    kind.add " and odd"
+  result = fmt"{n} is {kind}."
+
+
+## greetPerson* builds a greeting tailored to a person's age bracket.
+##
+## Parameters:
+## * `person` — The `Person` instance to greet.
+##
+## The procedure demonstrates chained `if` statements and string
+## interpolation. It returns the message instead of printing directly so that it
+## can be reused by other modules if desired.
+proc greetPerson*(person: Person): string =
+  if person.age < 18:
+    result = fmt"Hey {person.name}, enjoy your studies!"
+  elif person.age < 65:
+    result = fmt"Hello {person.name}, hope work is going well."
+  else:
+    result = fmt"Good afternoon {person.name}, wishing you a relaxing day!"
+
+
+## buildCountdown* constructs a descending list to illustrate loop control.
+##
+## Parameters:
+## * `start` — Highest value to include.
+##
+## The procedure uses a `while` loop to create a countdown sequence, stopping
+## at zero. It raises a `ValueError` when `start` is negative so callers learn
+## how to leverage exceptions in simple scripts.
+proc buildCountdown*(start: int): seq[int] =
+  if start < 0:
+    raise newException(ValueError, "Countdown requires a non-negative start.")
+  var current = start
+  while current >= 0:
+    result.add current
+    dec current
+
+
+when isMainModule:
+  echo "=== Control Flow Demonstration ==="
+
+  let demoPerson = Person(name: "Avery", age: 27)
+  echo greetPerson(demoPerson)
+
+  echo "\n--- Number classification ---"
+  for number in -2..3:
+    echo classifyNumber(number)
+
+  echo "\n--- Countdown ---"
+  for value in buildCountdown(5):
+    stdout.write(fmt"{value} ")
+  echo "\nBlastoff!"
+
+  echo "\n--- Error handling preview ---"
+  try:
+    discard buildCountdown(-1)
+  except ValueError as err:
+    echo "Tried to build a countdown with -1 and caught: ", err.msg

--- a/examples/cpp_helpers.hpp
+++ b/examples/cpp_helpers.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+inline int addOne(int value) {
+    return value + 1;
+}

--- a/examples/error_handling_and_options.nim
+++ b/examples/error_handling_and_options.nim
@@ -1,0 +1,95 @@
+## Demonstrates Nim's exception system and the `Option[T]` type for recoverable
+## flows.
+##
+## Run with `nim r examples/error_handling_and_options.nim` to watch several
+## strategies for dealing with failures.
+
+import std/[options, strformat, strutils]
+
+
+type
+  ## CalculationError* surfaces invalid numeric operations such as division by
+  ## zero.
+  ##
+  ## Raising this custom exception makes it easy for callers to catch only the
+  ## errors they expect while letting unrelated issues bubble up. Deriving from
+  ## `CatchableError` allows the exception to be trapped in user code.
+  CalculationError* = object of CatchableError
+
+
+## safeDivide* divides two floating-point numbers while guarding against
+## division-by-zero scenarios.
+##
+## Parameters:
+## * `numerator` — Value on the top of the fraction.
+## * `denominator` — Value on the bottom of the fraction.
+##
+## The procedure raises `CalculationError` whenever the denominator is too close
+## to zero, using a configurable epsilon to avoid floating-point surprises.
+proc safeDivide*(numerator, denominator: float): float =
+  const epsilon = 1e-9
+  if abs(denominator) < epsilon:
+    raise newException(CalculationError, "Cannot divide by zero or near-zero.")
+  numerator / denominator
+
+
+## parsePositiveInt* converts `text` to a strictly positive integer wrapped in an
+## option.
+##
+## Parameters:
+## * `text` — String containing the digits to parse.
+##
+## On successful parsing of a value greater than zero the procedure returns
+## `some(value)`. Invalid input or non-positive numbers yield `none(int)`,
+## allowing callers to pattern match on the result instead of raising errors.
+proc parsePositiveInt*(text: string): Option[int] =
+  try:
+    let parsed = parseInt(text)
+    if parsed > 0:
+      result = some(parsed)
+    else:
+      result = none(int)
+  except ValueError:
+    result = none(int)
+
+
+## attemptDivision* returns an optional quotient using `safeDivide` for the heavy
+## lifting.
+##
+## Parameters:
+## * `numerator` — Dividend.
+## * `denominator` — Divisor.
+##
+## A `CalculationError` from `safeDivide` is transformed into `none(float)`,
+## allowing callers to handle the absence of a result without a `try` block.
+proc attemptDivision*(numerator, denominator: float): Option[float] =
+  try:
+    some(safeDivide(numerator, denominator))
+  except CalculationError:
+    none(float)
+
+
+when isMainModule:
+  echo "=== Option type parsing ==="
+  for sample in @["42", "-10", "abc"]:
+    let parsed = parsePositiveInt(sample)
+    if parsed.isSome:
+      echo fmt"Successfully parsed {sample} as {parsed.get}."
+    else:
+      echo fmt"Input {sample} is not a positive integer."
+
+  echo "\n=== Exception handling ==="
+  for pair in @[ (numerator: 10.0, denominator: 2.0), (numerator: 5.0, denominator: 0.0) ]:
+    try:
+      let quotient = safeDivide(pair.numerator, pair.denominator)
+      echo fmt"{pair.numerator} / {pair.denominator} = {quotient}"
+    except CalculationError as err:
+      echo fmt"Could not divide {pair.numerator} by {pair.denominator}: {err.msg}"
+
+  echo "\n=== Options from divisions ==="
+  for pair in @[ (numerator: 9.0, denominator: 3.0), (numerator: 1.0, denominator: 0.0) ]:
+    let maybeQuotient = attemptDivision(pair.numerator, pair.denominator)
+    if maybeQuotient.isSome:
+      echo fmt"Quotient is {maybeQuotient.get}."
+    else:
+      echo fmt"Division failed for {pair.numerator} / {pair.denominator}."

--- a/examples/interop_c_and_cpp.nim
+++ b/examples/interop_c_and_cpp.nim
@@ -1,0 +1,48 @@
+## Demonstrates calling C and C++ routines directly from Nim code.
+##
+## Run with `nim r examples/interop_c_and_cpp.nim` to observe the C interop
+## output. For the optional C++ portion, run `nim cpp --run examples/interop_c_and_cpp.nim`.
+
+import std/strformat
+
+
+## cStringLength* exposes the C `strlen` function for measuring UTF-8 byte length.
+##
+## Parameters:
+## * `text` — Null-terminated string to measure. Use Nim's `.cstring` converter.
+##
+## Returns the number of bytes before the terminator, mirroring the C standard
+## library behavior.
+proc cStringLength*(text: cstring): csize_t {.importc: "strlen", header: "<string.h>".}
+
+
+## cPrintLine* wraps the C `puts` function to print a line using the C standard
+## library.
+##
+## Parameters:
+## * `text` — Null-terminated string. Nim automatically appends a newline.
+##
+## The function returns the status code from `puts`. Discard the result if you do
+## not need to inspect it.
+proc cPrintLine*(text: cstring): cint {.importc: "puts", header: "<stdio.h>".}
+
+
+when defined(cpp):
+  ## cppAddOne* calls a helper C++ inline function defined in `cpp_helpers.hpp`.
+  ##
+  ## Parameters:
+  ## * `value` — Integer forwarded to the C++ helper.
+  ##
+  ## The example showcases `importcpp` with a Nim call that expands to a C++
+  ## function invocation. Compile with the C++ backend (`nim cpp`) for this code
+  ## path to activate.
+  proc cppAddOne*(value: cint): cint {.importcpp: "addOne(@)", header: "\"cpp_helpers.hpp\"".}
+
+
+when isMainModule:
+  let greeting = "Hello from Nim via C!"
+  echo fmt"Byte length reported by strlen: {cStringLength(greeting.cstring)}"
+  discard cPrintLine("Printed by the C standard library.".cstring)
+
+  when defined(cpp):
+    echo fmt"C++ helper reports 7 + 1 = {cppAddOne(7)}"


### PR DESCRIPTION
## Summary
- add standalone example modules covering control flow, generics/metaprogramming, error handling with options, and C/C++ interop
- document each example with commands and expected output in examples/README.md and provide a helper C++ header
- extend NimLearning.nimble with reusable example lists plus tasks for compiling and running examples by argument or EXAMPLE env var

## Testing
- nimble examplesDebug
- nimble examplesRelease
- nimble runExample basic_control_flow
- EXAMPLE=error_handling_and_options nimble runExample


------
 