### PR TITLE
docs: expand overview and add build log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # Nim Learning
 
-Nim Learning is an educational sandbox for exploring the Nim programming language.
-The project will grow into a curated collection of lessons, executable examples,
-reference notes, and exercises that help developers practice core Nim concepts.
+Nim Learning is an educational sandbox for exploring the Nim programming language. The repository collects runnable examples, notes, and tooling that reinforce core language concepts through hands-on experimentation.
 
-## Project Layout
+## Project Overview
+
+- **Guided source code** – Start from the minimal entry point in [`src/nim_learning.nim`](src/nim_learning.nim) and branch into progressively richer examples under [`examples/`](examples). Each snippet highlights a different language feature while remaining small enough to understand in one sitting.
+- **Curated build tasks** – Custom Nimble tasks wrap commonly used compiler configurations so you can focus on learning rather than memorising flag combinations.
+- **Cross-language experiments** – Selected modules demonstrate how Nim interfaces with C and C++, as well as how its metaprogramming facilities reduce boilerplate.
+- **Windows GUI demo** – A wNim-based sample shows how Nim applications can present native user interfaces.
+
+For a deeper explanation of the showcased concepts and direct references to the relevant procedures, see the [Nim feature notes](docs/nim-feature-notes.md).
+
+## Repository Layout
 
 ```
 Nim_Learning/
-├── docs/        # Guides, tutorials, and reference material
+├── docs/        # Guides, logs, and background material
 ├── examples/    # Small runnable snippets that complement the lessons
 ├── src/         # Library and application source code (main module lives here)
 ├── tests/       # Future automated checks for the curriculum
@@ -16,54 +23,62 @@ Nim_Learning/
 └── README.md    # Project overview and contributor onboarding
 ```
 
-## Build Tasks
+## Requirements
 
-All builds are driven through the custom Nimble tasks defined in
-`NimLearning.nimble`. The tasks reuse shared option lists so you can tweak
-compiler behavior in a single place.
+- Nim 1.6 or newer with `nimble` available on your `PATH`.
+- A C toolchain (GCC or Clang) for compiling native binaries.
+- Optional: a Windows environment with the [wNim](https://github.com/khchen/wNim) package installed when experimenting with the GUI demo.
 
-| Task | Command | Purpose |
+## Building and Running
+
+Nimble drives every build from [`NimLearning.nimble`](NimLearning.nimble). The custom tasks reuse shared flag lists so that compiler behaviour can be tweaked in one location.
+
+| Task | Command | What it does |
 | --- | --- | --- |
-| Debug build | `nimble buildDebug` | Compiles `src/nim_learning.nim` with debug symbols and safety checks enabled. |
-| Release build | `nimble buildRelease` | Produces an optimized build using the default C backend. |
-| C backend | `nimble buildC` | Builds with the Nim C backend via GCC using the release optimization set. |
-| C++ backend | `nimble buildCpp` | Builds with the Nim C++ backend via Clang while reusing the release optimization set. |
+| Debug build | `nimble buildDebug` | Builds `src/nim_learning.nim` with debug symbols and extra runtime checks. |
+| Release build | `nimble buildRelease` | Produces an optimised build targeting the default C backend. |
+| C backend | `nimble buildC` | Rebuilds the main module with the GCC-backed C toolchain. |
+| C++ backend | `nimble buildCpp` | Switches to the Clang-based C++ backend to mirror `nim cpp`. |
+| Example runner | `nimble runExample <module>` | Compiles and executes one of the examples listed below. |
+| GUI sample | `nimble runGui` | Compiles and launches the wNim demo (Windows only). |
 
-> **Note:** If `nimble` is not available in your environment, you can execute the
-> same commands by running `nim` with the options printed at the start of each task.
+> **Tip:** each task prints the exact `nim` command before compiling. Copy the output to experiment with additional flags such as `--cpu:arm64` or `--threads:on`.
+
+A recent execution log for the build tasks is available in [`docs/build-log.md`](docs/build-log.md).
+
+## Example Showcase
+
+Use `nimble runExample <name>` (or `nim r examples/<name>.nim`) to explore the following topics:
+
+| Module | Highlights |
+| --- | --- |
+| [`basic_control_flow.nim`](examples/basic_control_flow.nim) | Branching logic, string interpolation, and loop control with error handling for invalid input. |
+| [`abstractions_and_metaprogramming.nim`](examples/abstractions_and_metaprogramming.nim) | Generics, iterators, templates, and macros that generate helpful debug output. |
+| [`error_handling_and_options.nim`](examples/error_handling_and_options.nim) | Custom exceptions combined with `Option[T]` workflows for recoverable operations. |
+| [`interop_c_and_cpp.nim`](examples/interop_c_and_cpp.nim) | Calling C standard-library functions and optionally invoking inline C++ helpers. |
+
+Each module is documented inline and is cross-referenced in the [feature notes](docs/nim-feature-notes.md) with explanations about why the showcased patterns are useful.
 
 ## Windows GUI Demo (wNim)
 
-The project ships with an interactive GUI example located at
-`src/gui/wnim_demo.nim`. It uses the [wNim](https://github.com/khchen/wNim)
-framework, which only supports Windows. A `requires "wNim >= 1.0.0"` entry is
-present in `NimLearning.nimble` so that Nimble fetches the dependency when
-available.
+The project ships with an interactive GUI example located at [`src/gui/wnim_demo.nim`](src/gui/wnim_demo.nim). It uses the [wNim](https://github.com/khchen/wNim) framework, which currently targets Windows.
 
 ### Prerequisites
 
-1. A Windows environment (Windows 10 or newer is recommended) with Nim 1.6+ and
-   the `nimble` tool on your `PATH`.
-2. The wNim package. Install it with `nimble install wNim` on Windows. If Nimble
-   cannot download the repository automatically, follow the manual steps
-   described by the project:
+1. Windows 10 or later with Nim 1.6+ and `nimble` on your `PATH`.
+2. The wNim package (`nimble install wNim`). If Nimble cannot download the repository automatically:
    - Download the wNim archive from GitHub.
-   - Extract it and open a command prompt inside the folder containing
-     `wnim.nimble`.
+   - Extract it and open a command prompt inside the folder containing `wnim.nimble`.
    - Run `nimble install` to register the package locally.
 
 ### Running the demo
 
-- Preferred: `nimble runGui` — compiles and runs the sample with the correct
-  `--app:gui` flag and prints a helpful message when invoked on non-Windows
-  systems.
-- Manual alternative: `nim c -r --app:gui src/gui/wnim_demo.nim` (add
-  `--cc:vcc` or `--cpu:x86` if you need to target a specific compiler/CPU).
+- Preferred: `nimble runGui` — compiles and runs the sample with the correct `--app:gui` flag. On non-Windows systems the task exits with a descriptive message instead of attempting to build the binary.
+- Manual alternative: `nim c -r --app:gui src/gui/wnim_demo.nim` (use `--cc:vcc` or `--cpu:x86` to target a specific compiler/CPU).
 
 ### What you will see
 
-Running the task opens a window titled **“Nim Learning wNim Demo”** that
-showcases:
+Running the task opens a window titled **“Nim Learning wNim Demo”** that showcases:
 
 - Buttons that count how many times they were pressed.
 - A text box with live mirroring of your input into a nearby label.
@@ -72,28 +87,11 @@ showcases:
 - An activity log (`ListBox`) that captures every interaction.
 - A status bar and menu bar (`File → Exit`, `View → Clear Activity Log`).
 
-Interacting with any control updates both the log and the status bar, making it
-easy to trace which widget fired its event.
+Interacting with any control updates both the log and the status bar, making it easy to trace which widget fired its event.
 
-## Configuration Variables
+## Additional Notes
 
-At the top of `NimLearning.nimble` you will find reusable sequences that
-encapsulate compiler flags and backend selections:
+- Configuration variables such as `baseOptions`, `releaseOptions`, and the backend selectors live near the top of [`NimLearning.nimble`](NimLearning.nimble). Adjust them to experiment with different targets without rewriting each task.
+- Suggested improvements and broader lesson outlines are tracked in [`docs/nim-feature-notes.md`](docs/nim-feature-notes.md); the document also links back to the relevant procedures so you can see how theory maps to code.
 
-- `baseOptions` – shared across every task to silence noisy hints.
-- `debugOptions` / `releaseOptions` – extend the base options with debugging or
-  performance-oriented flags.
-- `gccBackend` / `clangCppBackend` – switch the compiler backend between GCC and
-  Clang (`--cpp`).
-- `compileSteps` and `mainModule` – describe what should be built, letting tasks
-  reference the same entry point.
-
-Update these sequences to experiment with different CPUs (`--cpu:arm64`),
-operating systems (`--os:linux`), or additional flags without touching the task
-implementations.
-
-## Next Steps
-
-- Flesh out the `docs/` and `examples/` directories with instructional content.
-- Add tests under `tests/` to validate code samples and exercises.
-- Expand `src/` with reusable utilities that support the lessons.
+Happy hacking!

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -1,0 +1,59 @@
+# Nimble task log
+
+The following commands were executed on Linux using Nim 1.6.14 and Nimble 0.13.1. Outputs are truncated to the most relevant lines for readability.
+
+## `nimble buildDebug`
+
+```
+Executing: nim --hint[Processing]:off --hint[Conf]:off -g --lineDir:on --stackTrace:on --cc:gcc c src/nim_learning.nim
+Hint:  [Link]
+Hint: gc: refc; opt: none (DEBUG BUILD, `-d:release` generates faster code)
+41117 lines; 2.422s; 60.902MiB peakmem; proj: /workspace/Nim_Learning/src/nim_learning.nim; out: /workspace/Nim_Learning/src/nim_learning [SuccessX]
+```
+
+## `nimble buildRelease`
+
+```
+Executing: nim --hint[Processing]:off --hint[Conf]:off -d:release --opt:speed --stackTrace:off --cc:gcc c src/nim_learning.nim
+Hint:  [Link]
+Hint: gc: refc; opt: speed; options: -d:release
+41117 lines; 3.222s; 48.941MiB peakmem; proj: /workspace/Nim_Learning/src/nim_learning.nim; out: /workspace/Nim_Learning/src/nim_learning [SuccessX]
+```
+
+## `nimble buildC`
+
+```
+Executing: nim --hint[Processing]:off --hint[Conf]:off -d:release --opt:speed --stackTrace:off --cc:gcc c src/nim_learning.nim
+Hint:  [Link]
+Hint: gc: refc; opt: speed; options: -d:release
+41117 lines; 0.891s; 48.895MiB peakmem; proj: /workspace/Nim_Learning/src/nim_learning.nim; out: /workspace/Nim_Learning/src/nim_learning [SuccessX]
+```
+
+## `nimble buildCpp`
+
+```
+Executing: nim --hint[Processing]:off --hint[Conf]:off -d:release --opt:speed --stackTrace:off --cc:clang --cpp c src/nim_learning.nim
+command line(1, 2) Error: invalid command line option: '--cpp'
+... FAILED: nim --hint[Processing]:off --hint[Conf]:off -d:release --opt:speed --stackTrace:off --cc:clang --cpp c src/nim_learning.nim [OSError]
+```
+
+> **Note:** Nim 1.6 recognises `nim cpp` or `--backend:cpp`. The task is preserved as-is so that the repository reflects the canonical command emitted by the Nimble script.
+
+## `nimble runGui`
+
+```
+The wNim GUI demo can only be built on Windows where wNim is supported.
+Error: Exception raised during nimble script execution
+```
+
+> **Note:** The message is expected on non-Windows systems; the task exits before attempting a build.
+
+## `nimble runExample basic_control_flow`
+
+```
+Executing: nim --hint[Processing]:off --hint[Conf]:off -g --lineDir:on --stackTrace:on --cc:gcc r examples/basic_control_flow.nim
+=== Control Flow Demonstration ===
+Hello Avery, hope work is going well.
+...
+Tried to build a countdown with -1 and caught: Countdown requires a non-negative start.
+```

--- a/docs/nim-feature-notes.md
+++ b/docs/nim-feature-notes.md
@@ -1,0 +1,35 @@
+# Nim feature notes
+
+This guide connects each learning module to the Nim language constructs it demonstrates. Use it alongside the inline comments in the source tree for a deeper understanding of how the examples are structured.
+
+## Entry point (`src/nim_learning.nim`)
+
+- `formatGreeting` shows how default parameters and string interpolation via `fmt"..."` make it straightforward to build friendly command-line output while keeping the main module tiny for rapid compilation cycles.【F:src/nim_learning.nim†L6-L14】
+
+## Basic control flow (`examples/basic_control_flow.nim`)
+
+- The `Person` object type wraps named fields and is exported (`*`) so other modules can reuse it when experimenting with branching logic.【F:examples/basic_control_flow.nim†L9-L16】
+- `classifyNumber` demonstrates nested `if`/`elif`/`else` expressions that return values, including string concatenation that depends on runtime parity checks.【F:examples/basic_control_flow.nim†L21-L36】
+- `greetPerson` illustrates how returning strings instead of printing directly makes procedures easier to compose in larger applications.【F:examples/basic_control_flow.nim†L39-L48】
+- `buildCountdown` combines guard clauses with a `while` loop and raises a `ValueError` to emphasise how Nim handles exceptional flows.【F:examples/basic_control_flow.nim†L51-L66】
+
+## Abstractions and metaprogramming (`examples/abstractions_and_metaprogramming.nim`)
+
+- `Box[T]` plus `initBox` and `mapBox` highlight Nim's generic type parameters and type inference when transforming stored values with higher-order procedures.【F:examples/abstractions_and_metaprogramming.nim†L11-L38】
+- The `everyOther` iterator keeps internal state between `yield` calls, showcasing how Nim lazily traverses collections without allocating temporary sequences.【F:examples/abstractions_and_metaprogramming.nim†L41-L55】
+- `withSeparator` is a template that generates reusable logging scaffolding at compile time, reinforcing how templates reduce boilerplate while keeping call sites tidy.【F:examples/abstractions_and_metaprogramming.nim†L58-L70】
+- `debugExpression` is a macro that prints the abstract syntax tree (AST) representation of an expression before returning the evaluated result, illustrating Nim's metaprogramming capabilities.【F:examples/abstractions_and_metaprogramming.nim†L73-L88】
+
+## Error handling and options (`examples/error_handling_and_options.nim`)
+
+- `CalculationError` derives from `CatchableError` to define a custom exception hierarchy suitable for end-user scripts.【F:examples/error_handling_and_options.nim†L11-L18】
+- `safeDivide` shows defensive programming with floating-point comparisons and exception raising when invariants are violated.【F:examples/error_handling_and_options.nim†L21-L34】
+- `parsePositiveInt` returns `Option[int]`, emphasising recoverable flows that avoid exceptions when parsing user input fails.【F:examples/error_handling_and_options.nim†L37-L49】
+- `attemptDivision` converts thrown errors into `Option[float]` values to keep the call site free from `try`/`except` blocks while still acknowledging potential failure.【F:examples/error_handling_and_options.nim†L52-L61】
+
+## C and C++ interop (`examples/interop_c_and_cpp.nim`)
+
+- `cStringLength` and `cPrintLine` use the `{.importc.}` pragma to bind directly to C standard-library functions for measuring string length and printing lines, respectively.【F:examples/interop_c_and_cpp.nim†L8-L25】
+- When compiled with the C++ backend, `cppAddOne` activates via `{.importcpp.}` to call an inline helper defined in `examples/cpp_helpers.hpp`, demonstrating conditional compilation with the `when defined(cpp)` guard.【F:examples/interop_c_and_cpp.nim†L27-L41】
+
+Refer back to the example modules after reading each section and tinker with the code to reinforce the concepts.


### PR DESCRIPTION
## Summary
- refresh the root README with a fuller project overview, build instructions, and example index
- add nim feature notes that link the documented concepts to the source modules
- capture recent nimble task output in a docs/build-log.md for future reference

## Testing
- nimble buildDebug
- nimble buildRelease
- nimble buildC
- nimble buildCpp *(fails on Nim 1.6 because `--cpp` is not recognised)*
- nimble runGui *(expected to exit early on non-Windows platforms)*
- nimble runExample basic_control_flow

 