### PR TITLE
Switch GUI demo to nimx tooling

### DIFF
--- a/NimLearning.nimble
+++ b/NimLearning.nimble
@@ -72,7 +72,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.6.0"
-requires "nimx >= 0.1.0"
+requires "nimx >= 0.2"
 
 # Tasks
 
@@ -121,6 +121,6 @@ task runExample, "Run a single example module. Provide the name (with or without
 
 task runGui, "Compile and launch the cross-platform nimx GUI demo":
   let module = "src/gui/nimx_demo.nim"
-  let opts = debugOptions & defaultBackend & runStep & @["--app:gui"]
+  let opts = debugOptions & defaultBackend & runStep & @["--threads:on"]
   runNimCommand(opts, module)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Nim Learning is an educational sandbox for exploring the Nim programming languag
 - **Guided source code** – Start from the minimal entry point in [`src/nim_learning.nim`](src/nim_learning.nim) and branch into progressively richer examples under [`examples/`](examples). Each snippet highlights a different language feature while remaining small enough to understand in one sitting.
 - **Curated build tasks** – Custom Nimble tasks wrap commonly used compiler configurations so you can focus on learning rather than memorising flag combinations.
 - **Cross-language experiments** – Selected modules demonstrate how Nim interfaces with C and C++, as well as how its metaprogramming facilities reduce boilerplate.
-- **Windows GUI demo** – A wNim-based sample shows how Nim applications can present native user interfaces.
+- **Cross-platform GUI demo** – A nimx-based sample highlights how Nim code can drive modern interfaces on Windows, macOS, and Linux.
 
 For a deeper explanation of the showcased concepts and direct references to the relevant procedures, see the [Nim feature notes](docs/nim-feature-notes.md).
 
@@ -27,7 +27,7 @@ Nim_Learning/
 
 - Nim 1.6 or newer with `nimble` available on your `PATH`.
 - A C toolchain (GCC or Clang) for compiling native binaries.
-- Optional: a Windows environment with the [wNim](https://github.com/khchen/wNim) package installed when experimenting with the GUI demo.
+- Optional: the [nimx](https://github.com/yglukhov/nimx) runtime prerequisites (for example SDL2 libraries) required by your platform when exploring the GUI demo.
 
 ## Building and Running
 
@@ -40,7 +40,7 @@ Nimble drives every build from [`NimLearning.nimble`](NimLearning.nimble). The c
 | C backend | `nimble buildC` | Rebuilds the main module with the GCC-backed C toolchain. |
 | C++ backend | `nimble buildCpp` | Switches to the Clang-based C++ backend to mirror `nim cpp`. |
 | Example runner | `nimble runExample <module>` | Compiles and executes one of the examples listed below. |
-| GUI sample | `nimble runGui` | Compiles and launches the wNim demo (Windows only). |
+| GUI sample | `nimble runGui` | Compiles and launches the nimx demo (desktop platforms with nimx prerequisites installed). |
 
 > **Tip:** each task prints the exact `nim` command before compiling. Copy the output to experiment with additional flags such as `--cpu:arm64` or `--threads:on`.
 
@@ -70,8 +70,8 @@ The project ships with an interactive GUI example located at [`src/gui/nimx_demo
 
 ### Running the demo
 
-- Preferred: `nimble runGui` — compiles and runs the sample with the correct `--app:gui` flag on every supported desktop platform.
-- Manual alternative: `nim c -r --app:gui src/gui/nimx_demo.nim` (add any `--cc:` or `--cpu:` switches you normally use).
+- Preferred: `nimble runGui` — compiles and runs the sample with the required `--threads:on` flag recommended by nimx.
+- Manual alternative: `nim c -r --threads:on src/gui/nimx_demo.nim` (add any `--cc:` or `--cpu:` switches you normally use).
 
 ### What you will see
 

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -42,11 +42,13 @@ command line(1, 2) Error: invalid command line option: '--cpp'
 ## `nimble runGui`
 
 ```
-The wNim GUI demo can only be built on Windows where wNim is supported.
-Error: Exception raised during nimble script execution
+Executing: nim --hint[Processing]:off --hint[Conf]:off -g --lineDir:on --stackTrace:on --cc:gcc r --threads:on src/gui/nimx_demo.nim
+Hint: gc: refc; threads: on; opt: none (DEBUG BUILD, `-d:release` generates faster code)
+could not load: libSDL2(|-2.0).so(|.0)
+Error: execution of an external program failed: '/root/.cache/nim/nimx_demo_d/nimx_demo_222629AAB6B329180B0DC5307449C8FE3CFE1C59 '
 ```
 
-> **Note:** The message is expected on non-Windows systems; the task exits before attempting a build.
+> **Note:** nimx compiles successfully, but the runtime needs the SDL2 shared library present on the host system before the demo can launch.
 
 ## `nimble runExample basic_control_flow`
 

--- a/docs/nim-feature-notes.md
+++ b/docs/nim-feature-notes.md
@@ -32,4 +32,9 @@ This guide connects each learning module to the Nim language constructs it demon
 - `cStringLength` and `cPrintLine` use the `{.importc.}` pragma to bind directly to C standard-library functions for measuring string length and printing lines, respectively.【F:examples/interop_c_and_cpp.nim†L8-L25】
 - When compiled with the C++ backend, `cppAddOne` activates via `{.importcpp.}` to call an inline helper defined in `examples/cpp_helpers.hpp`, demonstrating conditional compilation with the `when defined(cpp)` guard.【F:examples/interop_c_and_cpp.nim†L27-L41】
 
+## GUI demo (`src/gui/nimx_demo.nim`)
+
+- `launchDemo` wraps `runApplication` to construct a cross-platform window with a nimx declarative layout that instantiates labels, buttons, text fields, checkboxes, pop-up menus, and a table-backed activity log.【F:src/gui/nimx_demo.nim†L17-L143】
+- Each widget wires into closures that mutate shared state, refresh status labels, and append to the log so interactions immediately update the interface.【F:src/gui/nimx_demo.nim†L149-L220】
+
 Refer back to the example modules after reading each section and tinker with the code to reinforce the concepts.

--- a/src/gui/nimx_demo.nim
+++ b/src/gui/nimx_demo.nim
@@ -10,7 +10,7 @@
 ## imported from other modules. Use the `when isMainModule` block at the
 ## bottom to run the demo directly.
 
-import std/[strformat, strutils]
+import std/[intsets, strformat, strutils]
 import nimx/[window, layout, button, text_field, popup_button,
              scroll_view, table_view, table_view_cell]
 
@@ -173,7 +173,7 @@ proc launchDemo*() =
 
     logTable.onSelectionChange = proc () {.closure, gcsafe.} =
       var selectedIndex = -1
-      for idx in logTable.selectedRows:
+      for idx in logTable.selectedRows.items:
         selectedIndex = idx
         break
       if selectedIndex >= 0:


### PR DESCRIPTION
## Summary
- bump the nimx dependency in NimLearning.nimble and update the runGui task to compile with the threads flag required by nimx
- refresh the README, build log, and feature notes to describe the nimx demo, its cross-platform requirements, and the SDL2 runtime dependency
- adjust the GUI demo source to import intsets so selection handling compiles with the current nimx release

## Testing
- nimble runGui *(fails: missing SDL2 shared library in the container image)*
- nimble buildDebug

 