### PR TITLE
Remove GUI demo documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Nim Learning is an educational sandbox for exploring the Nim programming languag
 - **Guided source code** – Start from the minimal entry point in [`src/nim_learning.nim`](src/nim_learning.nim) and branch into progressively richer examples under [`examples/`](examples). Each snippet highlights a different language feature while remaining small enough to understand in one sitting.
 - **Curated build tasks** – Custom Nimble tasks wrap commonly used compiler configurations so you can focus on learning rather than memorising flag combinations.
 - **Cross-language experiments** – Selected modules demonstrate how Nim interfaces with C and C++, as well as how its metaprogramming facilities reduce boilerplate.
-- **Cross-platform GUI demo** – A nimx-based sample highlights how Nim code can drive modern interfaces on Windows, macOS, and Linux.
 
 For a deeper explanation of the showcased concepts and direct references to the relevant procedures, see the [Nim feature notes](docs/nim-feature-notes.md).
 
@@ -27,7 +26,6 @@ Nim_Learning/
 
 - Nim 1.6 or newer with `nimble` available on your `PATH`.
 - A C toolchain (GCC or Clang) for compiling native binaries.
-- Optional: the [nimx](https://github.com/yglukhov/nimx) runtime prerequisites (for example SDL2 libraries) required by your platform when exploring the GUI demo.
 
 ## Building and Running
 
@@ -40,7 +38,6 @@ Nimble drives every build from [`NimLearning.nimble`](NimLearning.nimble). The c
 | C backend | `nimble buildC` | Rebuilds the main module with the GCC-backed C toolchain. |
 | C++ backend | `nimble buildCpp` | Switches to the Clang-based C++ backend to mirror `nim cpp`. |
 | Example runner | `nimble runExample <module>` | Compiles and executes one of the examples listed below. |
-| GUI sample | `nimble runGui` | Compiles and launches the nimx demo (desktop platforms with nimx prerequisites installed). |
 
 > **Tip:** each task prints the exact `nim` command before compiling. Copy the output to experiment with additional flags such as `--cpu:arm64` or `--threads:on`.
 
@@ -58,33 +55,6 @@ Use `nimble runExample <name>` (or `nim r examples/<name>.nim`) to explore the f
 | [`interop_c_and_cpp.nim`](examples/interop_c_and_cpp.nim) | Calling C standard-library functions and optionally invoking inline C++ helpers. |
 
 Each module is documented inline and is cross-referenced in the [feature notes](docs/nim-feature-notes.md) with explanations about why the showcased patterns are useful.
-
-## Cross-Platform GUI Demo (nimx)
-
-The project ships with an interactive GUI example located at [`src/gui/nimx_demo.nim`](src/gui/nimx_demo.nim). It uses the [nimx](https://github.com/yglukhov/nimx) framework so the same code runs on Windows, macOS, and Linux.
-
-### Prerequisites
-
-1. Nim 1.6+ with `nimble` available on your `PATH`.
-2. The nimx package (`nimble install nimx`). Follow the [nimx documentation](https://github.com/yglukhov/nimx#prerequisites) for any platform-specific runtime libraries such as SDL2.
-
-### Running the demo
-
-- Preferred: `nimble runGui` — compiles and runs the sample with the required `--threads:on` flag recommended by nimx.
-- Manual alternative: `nim c -r --threads:on src/gui/nimx_demo.nim` (add any `--cc:` or `--cpu:` switches you normally use).
-
-### What you will see
-
-Running the task opens a window titled **“Nim Learning nimx Demo”** that showcases:
-
-- Buttons that count how many times they were pressed.
-- A text box with live mirroring of your input into a nearby label.
-- A checkbox toggling whether the button message is verbose.
-- A combo box that logs the selected topic.
-- An activity log backed by a `TableView` that captures every interaction.
-- A status readout mirrored both in-window and in the title bar.
-
-Interacting with any control updates both the log and the status readout so you always know which widget fired its event.
 
 ## Additional Notes
 

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -39,17 +39,6 @@ command line(1, 2) Error: invalid command line option: '--cpp'
 
 > **Note:** Nim 1.6 recognises `nim cpp` or `--backend:cpp`. The task is preserved as-is so that the repository reflects the canonical command emitted by the Nimble script.
 
-## `nimble runGui`
-
-```
-Executing: nim --hint[Processing]:off --hint[Conf]:off -g --lineDir:on --stackTrace:on --cc:gcc r --threads:on src/gui/nimx_demo.nim
-Hint: gc: refc; threads: on; opt: none (DEBUG BUILD, `-d:release` generates faster code)
-could not load: libSDL2(|-2.0).so(|.0)
-Error: execution of an external program failed: '/root/.cache/nim/nimx_demo_d/nimx_demo_222629AAB6B329180B0DC5307449C8FE3CFE1C59 '
-```
-
-> **Note:** nimx compiles successfully, but the runtime needs the SDL2 shared library present on the host system before the demo can launch.
-
 ## `nimble runExample basic_control_flow`
 
 ```

--- a/docs/nim-feature-notes.md
+++ b/docs/nim-feature-notes.md
@@ -32,9 +32,4 @@ This guide connects each learning module to the Nim language constructs it demon
 - `cStringLength` and `cPrintLine` use the `{.importc.}` pragma to bind directly to C standard-library functions for measuring string length and printing lines, respectively.【F:examples/interop_c_and_cpp.nim†L8-L25】
 - When compiled with the C++ backend, `cppAddOne` activates via `{.importcpp.}` to call an inline helper defined in `examples/cpp_helpers.hpp`, demonstrating conditional compilation with the `when defined(cpp)` guard.【F:examples/interop_c_and_cpp.nim†L27-L41】
 
-## GUI demo (`src/gui/nimx_demo.nim`)
-
-- `launchDemo` wraps `runApplication` to construct a cross-platform window with a nimx declarative layout that instantiates labels, buttons, text fields, checkboxes, pop-up menus, and a table-backed activity log.【F:src/gui/nimx_demo.nim†L17-L143】
-- Each widget wires into closures that mutate shared state, refresh status labels, and append to the log so interactions immediately update the interface.【F:src/gui/nimx_demo.nim†L149-L220】
-
 Refer back to the example modules after reading each section and tinker with the code to reinforce the concepts.


### PR DESCRIPTION
## Summary
- remove the GUI demo bullet, requirement, and task row from the README to keep the overview focused on the active examples
- prune the GUI section from the feature notes and build log so the documentation reflects only the supported console-based material

## Testing
- not run (documentation-only change)

 